### PR TITLE
Improved compatibility with Posix

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ runs:
 
     - name: Create json and invoke webhook
       run: |
-        $json = ConvertTo-Json @{issues = @(${{ env.RELATED_JIRA_ISSUES }}); data = @{version = "${{ inputs.build-version }}"; projectName = "${{ inputs.jira-project-key }}"}}
+        $json = ConvertTo-Json @{issues = @("${{ env.RELATED_JIRA_ISSUES }}"); data = @{version = "${{ inputs.build-version }}"; projectName = "${{ inputs.jira-project-key }}"}}
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
         Invoke-RestMethod ${{ inputs.jira-automation-webhook }} -Method Post -Body $json -ContentType "application/json"
       shell: pwsh

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ runs:
         export LC_ALL=en_US.utf8
         git log $(git describe --abbrev=0 2> /dev/null || git rev-list --max-parents=0 HEAD)..HEAD | \
           grep -oE "${{ inputs.jira-project-key }}-[[:digit:]]{1,}" | sort | uniq | \
-          sed 's/^\|$/"/g' | paste -sd , | awk '{print "RELATED_JIRA_ISSUES="$0}' >> $GITHUB_ENV
+          sed 's/^\|$/"/g' | paste -sd , - | awk '{print "RELATED_JIRA_ISSUES="$0}' >> $GITHUB_ENV
       shell: bash
 
     - name: Create json and invoke webhook


### PR DESCRIPTION
There are patches that I used for mac os runner compatibility.
1. Added explicit stdin operator '-' that optional in linux coreutils but required in mac os.
2. "${{ env.RELATED_JIRA_ISSUES }}" escaped in powershell to avoid syntax error. 