### PR TITLE
Update action.yml: catch lightweight tags

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,7 @@ runs:
     - name: Collect issue numbers since last release/tag
       run: |
         export LC_ALL=en_US.utf8
-        git log $(git describe --abbrev=0 2> /dev/null || git rev-list --max-parents=0 HEAD)..HEAD | \
+        git log $(git describe --abbrev=0 --tags 2> /dev/null || git rev-list --max-parents=0 HEAD)..HEAD | \
           grep -oE "${{ inputs.jira-project-key }}-[[:digit:]]{1,}" | sort | uniq | \
           sed 's/^\|$/"/g' | paste -sd , - | awk '{print "RELATED_JIRA_ISSUES="$0}' >> $GITHUB_ENV
       shell: bash


### PR DESCRIPTION
In my workflow this was always filling from the entire git history because we use lightweight tags to mark releases.  Opening this PR in case anyone else ran into a similar problem.