### PR TITLE
Update fetch to be resilient for already unshallow repositories

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,11 @@ runs:
   using: "composite"
   steps:
     - name: Fetch entire Git history (including tags)
-      run: git fetch --prune --unshallow --tags
+      run: |
+        if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
+          git fetch --prune --unshallow
+        fi
+        git fetch --prune --tags
       shell: bash
 
     - name: Collect issue numbers since last release/tag


### PR DESCRIPTION
Currently if the repo is already unshallow because of earlier steps in the workflow, this action will fail on `git fetch --prune --unshallow --tags` because unshallow can only be used with shallow repositories. This checks if the repository is shallow and only runs unshallow if it is, then fetches the tags. 