### PR TITLE
docs: Update usage to newer checkout version

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ See [action.yml](action.yml)
 
 ```yaml
 steps:
-- uses: actions/checkout@v2
+- uses: actions/checkout@v4
 
 - uses: GeoWerkstatt/create-jira-release@v1
   with:


### PR DESCRIPTION
Updating usage snippet to use checkout@v4 since v2 uses deprecated node version