### PR TITLE
Find the latest tag from HEADs first parent

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,7 @@ runs:
     - name: Collect issue numbers since last release/tag
       run: |
         export LC_ALL=en_US.utf8
-        git log $(git describe --abbrev=0 --tags 2> /dev/null || git rev-list --max-parents=0 HEAD)..HEAD | \
+        git log $(git describe --abbrev=0 --tags HEAD^ 2> /dev/null || git rev-list --max-parents=0 HEAD)..HEAD | \
           grep -oE "${{ inputs.jira-project-key }}-[[:digit:]]{1,}" | sort | uniq | \
           sed 's/^\|$/"/g' | paste -sd , - | awk '{print "RELATED_JIRA_ISSUES="$0}' >> $GITHUB_ENV
       shell: bash


### PR DESCRIPTION
In order to fix a race condition in one of our release workflows, the tag fetching logic has been updated. The smoking gun was the following logs from the run: 

```
Run export LC_ALL=en_US.utf8
  export LC_ALL=en_US.utf8
  git log $(git describe --abbrev=0 --tags 2> /dev/null || git rev-list --max-parents=0 HEAD)..HEAD | \
    grep -oE "GEOWARIS-[[:digit:]]{1,}" | sort | uniq | \
    sed 's/^\|$/"/g' | paste -sd , - | awk '{print "RELATED_JIRA_ISSUES="$0}' >> $GITHUB_ENV
  shell: C:\Program Files\Git\bin\bash.EXE --noprofile --norc -e -o pipefail {0}
  env:
    NUGET: C:\hostedtoolcache\windows\nuget.exe\7.3.0\x64/nuget.exe
    VERSION: 1.0.0.89
    AUTOMATIC_RELEASES_TAG: v1.0.0.89
##[debug]C:\Program Files\Git\bin\bash.EXE --noprofile --norc -e -o pipefail D:\a\_temp\af270859-746d-498e-bce2-c5e0b32e49f2.sh
Error: Process completed with exit code 1.

```
### Hypothesis 
When `git log` writes nothing to `stdout`, `grep` tries filtering the lack of output and fails with `exit code 1`.
### Reason
`git log` outputs nothing because we create a new release, and apply a tag to `HEAD`, before we run this action. Since there are no additional commits after `HEAD`, there is nothing to output, and the filtering block fails.
### Solution
By adding `HEAD^` to the `git describe` command (`git describe --abbrev=0 --tags HEAD^`) we make sure to fetch latest tag from the first parent of `HEAD`, effectively searching from the point of one commit "earlier". This will return all commits from the last tag onwards, up to `HEAD`. This change should be non-breaking for all but one edge case, that is already dealt with in the code. The edge case is, if there is only a single commit in the entire git history (caught by `|| git rev-list --max-parents=0 HEAD`).
### Open issues
If none of the commits contain the jira ticket names, the action would still fail. This is, however, an existing problem with the previous logic as well.